### PR TITLE
Easier worklfow with panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+All notable changes to this project will be documented in this file.
+# Changelog
+
+## [0.2.3] - 2024-02-28
+### Added
+- When going into nested collection, show return Main Scene button (also removes all tmp scenes)
+
+## [0.2.2] - 2024-02-22
+### Added
+- Center new created scene on enter (fixes zoom level)
+- Center on instance when return to scene (fixes zoom level)
+- Panel in N so we see a button (easier naviation)
+- Scene will be deleted when using the new operator (button)
+
+## [0.2.1] - 2022-11-24
+### Added
+- Add view-aligned checkerboard pattern and gray background options, and a Preferences-panel option to select which to use.
+
+## [0.2.0] - 2022-11-22
+### Added
+- Adds a checkerboard pattern to the background of the temporary for lighting and reflections.
+- Use build_release.py and move code into an src directory.
+
+## [0.1.0] - 2022-07-15
+### New
+- Initial addon setup
+
+## Notes
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+<!--### Official Rigify Info-->
+
+[0.2.2]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.2
+[0.2.1]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.1.1
+
+[0.2.0]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.0
+[0.1.0]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <!--### Official Rigify Info-->
 
+[0.2.2]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.3
 [0.2.2]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.2
 [0.2.1]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <!--### Official Rigify Info-->
 
-[0.2.2]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.3
+[0.2.3]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.3
 [0.2.2]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.2
 [0.2.1]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 All notable changes to this project will be documented in this file.
 # Changelog
 
+## [0.2.4] - 2025-02-24
+### Added
+- When having different scenes and view_layers, it would not go back into proper view_layer of the scene
+
 ## [0.2.3] - 2024-02-28
 ### Added
 - When going into nested collection, show return Main Scene button (also removes all tmp scenes)
@@ -30,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <!--### Official Rigify Info-->
 
+[0.2.4]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.4
 [0.2.3]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.3
 [0.2.2]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.2
 [0.2.1]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 All notable changes to this project will be documented in this file.
 # Changelog
 
+## [0.2.6] - 2025-04-02
+### Fixed
+- Issue with viewlayer and multiple scene. When going back to previews scene, it would pick wrong scene from list > EIC_OP_ReturntoScene
+
+## [0.2.5] - 2025-03-31
+### Added
+- Active world shader > use same as actiive scene. Good for matching materials using same lighting
+
 ## [0.2.4] - 2025-02-24
 ### Added
 - When having different scenes and view_layers, it would not go back into proper view_layer of the scene
@@ -34,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <!--### Official Rigify Info-->
 
+[0.2.4]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.6
 [0.2.4]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.4
 [0.2.3]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.3
 [0.2.2]:https://github.com/SuperFLEB/BlenderEditCollectionAddon/releases/tag/v.0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.5] - 2025-03-31
 ### Added
-- Active world shader > use same as actiive scene. Good for matching materials using same lighting
+- Active world shader > use same as active scene. Good for matching materials using same lighting
 
 ## [0.2.4] - 2025-02-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ made by the addon (usually, using the Clean Up tools). -->
 
 ## Preview
 
-!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/Wiki/Edit-Easier-Workflow-v023-720p.mp4?v20220924)
+!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/images/Edit-Easier-Workflow-v023-720p.mp4?v20220924)
 
 
 ### System Requirements
@@ -61,3 +61,4 @@ made by the addon (usually, using the Clean Up tools). -->
 
 
 
+https://raw.githubusercontent.com/wiki/schroef/quickswitch/images/addon-preferences_v023.png?v20220923

--- a/README.md
+++ b/README.md
@@ -8,10 +8,22 @@ the current Scene, but not the Collection itself.
 Since it was a relatively reproducible process to find and link the Collections, I created this addon that allows quickly
 dropping in to edit the underlying Collection of a Collection Instance, and then dropping out.
 
-## To install
+<!-- ## To install
 
 Either install the ZIP file from the release or clone this repository and use the
 build_release.py script to build a ZIP file that you can install into Blender.
+ -->
+
+### Installation Process
+
+1. Download the latest <b>[release](https://github.com/SuperFLEB/BlenderEditCollectionAddon/)</b>
+2. If you downloaded the zip file.
+3. Open Blender.
+4. Go to File -> User Preferences -> Addons.
+5. At the bottom of the window, choose *Install From File*.
+6. Select the file `quickswitch-master.zip` from your download location..
+7. Activate the checkbox for the plugin that you will now find in the list.
+8. Set custom pie menu items by setting shortcuts for WM menu
 
 ## To Use
 
@@ -27,5 +39,25 @@ build_release.py script to build a ZIP file that you can install into Blender.
 6. Each time you return, the temp scene will automatically be deleted.
    When "Return to Main Scene" is used, all tmp scenes will be deleted.
 
-You can drill down to multiple levels, though you will have to be sure to clean up any temporary Scenes and Worlds
-made by the addon (usually, using the Clean Up tools).
+<!-- You can drill down to multiple levels, though you will have to be sure to clean up any temporary Scenes and Worlds
+made by the addon (usually, using the Clean Up tools). -->
+
+## Preview
+
+!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/wiki/Edit-Easier-Workflow-v023-720p.mp4?v20220923)
+
+
+### System Requirements
+
+| **OS** | **Blender** |
+| ------------- | ------------- |
+| OSX | Blender 3.1.0 |
+| Windows | Blender 3.1.0 |
+| Linux | Blender 3.1.0 |
+
+
+### Changelog
+[Full Changelog](CHANGELOG.md)
+
+
+

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ made by the addon (usually, using the Clean Up tools). -->
 
 ## Preview
 
-!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/images/Edit-Easier-Workflow-v023-720p.mp4?v20220924)
+!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/images/Edit-Easier-Workflow-v023-720p.gif?v20220924)
+<!-- !['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/images/Edit-Easier-Workflow-v023-720p.mp4?v20220924) -->
 
 
 ### System Requirements
@@ -61,4 +62,4 @@ made by the addon (usually, using the Clean Up tools). -->
 
 
 
-https://raw.githubusercontent.com/wiki/schroef/quickswitch/images/addon-preferences_v023.png?v20220923
+<!-- https://raw.githubusercontent.com/wiki/schroef/quickswitch/images/addon-preferences_v023.png?v20220923 -->

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ build_release.py script to build a ZIP file that you can install into Blender.
 3. Open Blender.
 4. Go to File -> User Preferences -> Addons.
 5. At the bottom of the window, choose *Install From File*.
-6. Select the file `quickswitch-master.zip` from your download location..
+6. Select the file `edit_instanced_collection_XXXX.zip` from your download location..
 7. Activate the checkbox for the plugin that you will now find in the list.
 8. Set custom pie menu items by setting shortcuts for WM menu
 
@@ -44,7 +44,7 @@ made by the addon (usually, using the Clean Up tools). -->
 
 ## Preview
 
-!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/wiki/Edit-Easier-Workflow-v023-720p.mp4?v20220923)
+!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/Wiki/Edit-Easier-Workflow-v023-720p.mp4?v20220924)
 
 
 ### System Requirements

--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ build_release.py script to build a ZIP file that you can install into Blender.
 
 1. Select a Collection Instance. (Selecting multiple Collection Instances is not supported.)
 2. Either from the Object menu or the spacebar/W context menu, select "Edit Instanced Collection", or use the hotkey (Ctrl+Alt+C)
-   in Object Mode.
+   in Object Mode. In the panel (N) > Item > Edit Instance Collection. We see buttons depending on the hierarchy.
 3. You will be dropped into a newly-created Scene containing nothing but the Collection. Edit the collection, and your
    edits will be reflected in all instances of the Collection.
-4. Once you are done editing (ensure that all new objects are within the Collection) delete the temporary Scene (named
-   "temp(name-of-collection)").
+4. In the panel (N) > Item > Edit Instance Collection. We see buttons depending on the hierarchy.
+   When there are nested Collection, we see again "Edit Collection", so we can go deeper into hierarchy
+5. Once in say level 2, we see a button "Previous Collection", this will return to the prior Collection
+   There is also a button "Return to Main Scene".
+6. Each time you return, the temp scene will automatically be deleted.
+   When "Return to Main Scene" is used, all tmp scenes will be deleted.
 
 You can drill down to multiple levels, though you will have to be sure to clean up any temporary Scenes and Worlds
 made by the addon (usually, using the Clean Up tools).

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ made by the addon (usually, using the Clean Up tools). -->
 
 ## Preview
 
-!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/images/Edit-Easier-Workflow-v023-720p.gif?v20220924)
-<!-- !['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/images/Edit-Easier-Workflow-v023-720p.mp4?v20220924) -->
+!['Look UI'](https://raw.githubusercontent.com/wiki/schroef/BlenderEditCollectionAddon/images/Edit-Easier-Workflow-v023-720p.gif?v20240228)
 
 
 ### System Requirements
@@ -59,7 +58,3 @@ made by the addon (usually, using the Clean Up tools). -->
 
 ### Changelog
 [Full Changelog](CHANGELOG.md)
-
-
-
-<!-- https://raw.githubusercontent.com/wiki/schroef/quickswitch/images/addon-preferences_v023.png?v20220923 -->

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -34,7 +34,6 @@ class EditCollection(bpy.types.Operator):
             self.report({"WARNING"}, "Active item is not a collection instance")
             return {"CANCELLED"}
 
-        # settings["original_scene"] = context.scene.name[:64] #.substring(0, 64)
         settings["original_scene"].append(context.scene.name[:64]) #.substring(0, 64)
         scene_name = f"temp:{str(coll.name)[:50]}"
         # print("Scene_name %s" % scene_name)
@@ -144,17 +143,7 @@ class EIC_PT_PanelLinkedEdit(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context: bpy.context):
-        # print(context.active_object)
-        # return settings["original_scene"] != ""
         return (context.active_object is not None) or (settings["original_scene"] != [])
-
-    # def draw_common(self, scene, layout, props):
-    #     if props is not None:
-    #         props.use_autosave = scene.use_autosave
-    #         props.use_instance = scene.use_instance
-
-    #         layout.prop(scene, "use_autosave")
-    #         layout.prop(scene, "use_instance")
 
     def draw(self, context: bpy.context):
         scene = context.scene
@@ -162,71 +151,18 @@ class EIC_PT_PanelLinkedEdit(bpy.types.Panel):
         layout.use_property_split = False
         layout.use_property_decorate = False
 
-        # layout.operator("object.eic_return_to_scene")
-
         target = None
 
         icon = 'OUTLINER_COLLECTION'
         try:
-            # icon = "OUTLINER_DATA_" + context.active_object.type.replace("LIGHT_PROBE", "LIGHTPROBE")
             target = context.active_object
-        
             if settings["original_scene"] == "" or settings["original_scene"] != "" and (target.instance_collection is not None):
-            # if settings["original_scene"] == "" and (target is not None):
-                    # (target and
-                    # target.library is not None) or
-                    # context.active_object.library is not None or
-                    # (context.active_object.override_library is not None and
-                    # context.active_object.override_library.reference is not None)):
-
                 if (target.instance_collection is not None):
                     props = layout.operator("object.edit_collection", icon="LINK_BLEND",
                                             text="Edit Collection") # %s" % target.name)
-            #     elif (context.active_object.library):
-            #         props = layout.operator("object.edit_linked", icon="LINK_BLEND",
-            #                                 text="Edit Library: %s" % context.active_object.name)
-            #     else:
-            #         props = layout.operator("object.edit_linked", icon="LINK_BLEND",
-            #                                 text="Edit Override Library: %s" % context.active_object.override_library.reference.name)
 
-            #     self.draw_common(scene, layout, props)
-
-            #     if (target is not None):
-            #         layout.label(text="Path: %s" %
-            #                     target.library.filepath)
-            #     elif (context.active_object.library):
-            #         layout.label(text="Path: %s" %
-            #                     context.active_object.library.filepath)
-            #     else:
-            #         layout.label(text="Path: %s" %
-            #                     context.active_object.override_library.reference.library.filepath)
             else:
                 layout.label(text="%s is not linked" % context.active_object.name,icon=icon)
-            
-            
-            #         layout.separator()
-
-            #         # XXX - This is for nested linked assets... but it only works
-            #         # when launching a new Blender instance. Nested links don't
-            #         # currently work when using a single instance of Blender.
-            #         if context.active_object.instance_collection is not None:
-            #             props = layout.operator("object.edit_linked",
-            #                     text="Edit Library: %s" % context.active_object.instance_collection.name,
-            #                     icon="LINK_BLEND")
-            #         else:
-            #             props = None
-
-            #         self.draw_common(scene, layout, props)
-
-            #         if context.active_object.instance_collection is not None:
-            #             layout.label(text="Path: %s" %
-            #                     context.active_object.instance_collection.library.filepath)
-
-            #     else:
-            #         props = layout.operator("wm.return_to_original", icon="LOOP_BACK")
-            #         props.use_autosave = scene.use_autosave
-
-            #         layout.prop(scene, "use_autosave")
         except:
             pass
         if settings["original_scene"] != []:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ bl_info = {
     "name": "Edit Instanced Collection",
     "description": "Edit a Collection Instance's source Collection (even if it is not in the Scene).",
     "author": "FLEB",
-    "version": (0, 2, 1),
+    "version": (0, 2, 3),
     "blender": (3, 1, 0),
     "location": "Object > Edit Instanced Collection",
     "doc_url": "https://github.com/SuperFLEB/BlenderEditCollectionAddon",
@@ -18,7 +18,6 @@ addon_keymaps = []
 package_name = __package__
 seen_popup = False
 
-
 class EditCollection(bpy.types.Operator):
     """Edit the Collection referenced by this Collection Instance in a new Scene"""
     bl_idname = "object.edit_collection"
@@ -29,17 +28,27 @@ class EditCollection(bpy.types.Operator):
         prefs = context.preferences.addons[package_name].preferences
         coll = bpy.context.active_object.instance_collection
 
+
         if not coll:
             print("Active item is not a collection instance")
             self.report({"WARNING"}, "Active item is not a collection instance")
             return {"CANCELLED"}
 
-        scene_name = f"temp:{coll.name}"
+        # settings["original_scene"] = context.scene.name[:64] #.substring(0, 64)
+        settings["original_scene"].append(context.scene.name[:64]) #.substring(0, 64)
+        scene_name = f"temp:{str(coll.name)[:50]}"
+        # print("Scene_name %s" % scene_name)
+        # print("Scene_name %s" % str(tmp_name)[:10])
+        # print("Scene_name %s" % scene_name[:10])
+        # print("Scene_name %s" % scene_name[:20])
+        # print("Scene_name %s" % scene_name[:30])
         bpy.ops.scene.new(type="EMPTY")
         new_scene = bpy.context.scene
         new_scene.name = scene_name
         bpy.context.window.scene = new_scene
         new_scene.collection.children.link(coll)
+
+        settings["tmp_scene"].append(scene_name)
 
         if prefs.world_texture != "none":
             world = bpy.data.worlds.new(bpy.context.scene.name)
@@ -84,9 +93,149 @@ class EditCollection(bpy.types.Operator):
             bpy.context.window_manager.popup_menu(message,
                                                   title=f"Temporary Scene \"{scene_name}\" Created",
                                                   icon="COLLECTION_NEW")
+        # Center view
+        bpy.ops.view3d.view_all(center=True)
 
         return {"FINISHED"}
 
+settings = {
+    "original_scene": [],
+    "tmp_scene": [],
+    # "linked_objects": [],
+    # "linked_nodes": []
+    }
+
+class EIC_OP_ReturntoScene(bpy.types.Operator):
+    """Return to main scene"""
+    bl_idname = "object.eic_return_to_scene"
+    bl_label = "Return to Scene"
+    bl_options = {"REGISTER", "UNDO"}
+
+    scene : bpy.props.StringProperty()
+
+    def execute(self, context):
+        if (self.scene == "previous"):
+            settings["tmp_scene"].remove(context.scene.name)
+            if (settings["tmp_scene"] == 0):
+                settings["original_scene"] =[]
+            else:
+                settings["original_scene"].pop(len(settings["original_scene"])-1)
+
+            bpy.ops.scene.delete()
+            bpy.ops.view3d.view_selected(use_all_regions=False)
+            # logger.info("Back to the original!")
+        if (self.scene == "main"):
+            for scn in settings["tmp_scene"]:
+                bpy.context.window.scene = bpy.data.scenes[scn]
+                bpy.ops.scene.delete()
+            bpy.ops.view3d.view_selected(use_all_regions=False)
+            settings["original_scene"] = []
+            settings["tmp_scene"] = []
+            # logger.info("Back to the original!")
+        return {'FINISHED'}
+
+class EIC_PT_PanelLinkedEdit(bpy.types.Panel):
+    bl_label = "Edit Instanced Collection"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = 'UI'
+    bl_category = "Item"
+    bl_context = 'objectmode'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    @classmethod
+    def poll(cls, context: bpy.context):
+        # print(context.active_object)
+        # return settings["original_scene"] != ""
+        return (context.active_object is not None) or (settings["original_scene"] != [])
+
+    # def draw_common(self, scene, layout, props):
+    #     if props is not None:
+    #         props.use_autosave = scene.use_autosave
+    #         props.use_instance = scene.use_instance
+
+    #         layout.prop(scene, "use_autosave")
+    #         layout.prop(scene, "use_instance")
+
+    def draw(self, context: bpy.context):
+        scene = context.scene
+        layout = self.layout
+        layout.use_property_split = False
+        layout.use_property_decorate = False
+
+        # layout.operator("object.eic_return_to_scene")
+
+        target = None
+
+        icon = 'OUTLINER_COLLECTION'
+        try:
+            # icon = "OUTLINER_DATA_" + context.active_object.type.replace("LIGHT_PROBE", "LIGHTPROBE")
+            target = context.active_object
+        
+            if settings["original_scene"] == "" or settings["original_scene"] != "" and (target.instance_collection is not None):
+            # if settings["original_scene"] == "" and (target is not None):
+                    # (target and
+                    # target.library is not None) or
+                    # context.active_object.library is not None or
+                    # (context.active_object.override_library is not None and
+                    # context.active_object.override_library.reference is not None)):
+
+                if (target.instance_collection is not None):
+                    props = layout.operator("object.edit_collection", icon="LINK_BLEND",
+                                            text="Edit Collection") # %s" % target.name)
+            #     elif (context.active_object.library):
+            #         props = layout.operator("object.edit_linked", icon="LINK_BLEND",
+            #                                 text="Edit Library: %s" % context.active_object.name)
+            #     else:
+            #         props = layout.operator("object.edit_linked", icon="LINK_BLEND",
+            #                                 text="Edit Override Library: %s" % context.active_object.override_library.reference.name)
+
+            #     self.draw_common(scene, layout, props)
+
+            #     if (target is not None):
+            #         layout.label(text="Path: %s" %
+            #                     target.library.filepath)
+            #     elif (context.active_object.library):
+            #         layout.label(text="Path: %s" %
+            #                     context.active_object.library.filepath)
+            #     else:
+            #         layout.label(text="Path: %s" %
+            #                     context.active_object.override_library.reference.library.filepath)
+            else:
+                layout.label(text="%s is not linked" % context.active_object.name,icon=icon)
+            
+            
+            #         layout.separator()
+
+            #         # XXX - This is for nested linked assets... but it only works
+            #         # when launching a new Blender instance. Nested links don't
+            #         # currently work when using a single instance of Blender.
+            #         if context.active_object.instance_collection is not None:
+            #             props = layout.operator("object.edit_linked",
+            #                     text="Edit Library: %s" % context.active_object.instance_collection.name,
+            #                     icon="LINK_BLEND")
+            #         else:
+            #             props = None
+
+            #         self.draw_common(scene, layout, props)
+
+            #         if context.active_object.instance_collection is not None:
+            #             layout.label(text="Path: %s" %
+            #                     context.active_object.instance_collection.library.filepath)
+
+            #     else:
+            #         props = layout.operator("wm.return_to_original", icon="LOOP_BACK")
+            #         props.use_autosave = scene.use_autosave
+
+            #         layout.prop(scene, "use_autosave")
+        except:
+            pass
+        if settings["original_scene"] != []:
+            if settings["tmp_scene"] != [] and len(settings["tmp_scene"]) != 1:
+                props = layout.operator("object.eic_return_to_scene", text = 'Previous Collection', icon=icon)
+                props.scene = 'previous'
+            if len(settings["tmp_scene"]) >= 1:
+                props = layout.operator("object.eic_return_to_scene", text='Return to Main Scene', icon='SCENE_DATA')
+                props.scene = 'main'
 
 class EditInstancedCollectionPreferences(bpy.types.AddonPreferences):
     bl_idname = package_name
@@ -117,11 +266,17 @@ def menu_function(self, context):
         self.layout.operator(EditCollection.bl_idname)
 
 
+classes = [
+    EIC_OP_ReturntoScene,
+    EIC_PT_PanelLinkedEdit
+]
 def register():
     global seen_popup
     seen_popup = False
 
     # Register classes
+    for cls in classes:
+        bpy.utils.register_class(cls)
     bpy.utils.register_class(EditCollection)
     bpy.utils.register_class(EditInstancedCollectionPreferences)
 
@@ -140,6 +295,9 @@ def register():
 
 def unregister():
     # Unregister classes
+    for cls in classes:
+        bpy.utils.unregister_class(cls)
+
     bpy.utils.unregister_class(EditCollection)
     bpy.utils.unregister_class(EditInstancedCollectionPreferences)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -106,7 +106,7 @@ settings = {
     }
 
 class EIC_OP_ReturntoScene(bpy.types.Operator):
-    """Return to main scene"""
+    """Return to scene / collection"""
     bl_idname = "object.eic_return_to_scene"
     bl_label = "Return to Scene"
     bl_options = {"REGISTER", "UNDO"}
@@ -234,7 +234,7 @@ class EIC_PT_PanelLinkedEdit(bpy.types.Panel):
                 props = layout.operator("object.eic_return_to_scene", text = 'Previous Collection', icon=icon)
                 props.scene = 'previous'
             if len(settings["tmp_scene"]) >= 1:
-                props = layout.operator("object.eic_return_to_scene", text='Return to Main Scene', icon='SCENE_DATA')
+                props = layout.operator("object.eic_return_to_scene", text='Return to Scene', icon='SCENE_DATA')
                 props.scene = 'main'
 
 class EditInstancedCollectionPreferences(bpy.types.AddonPreferences):

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ bl_info = {
     "name": "Edit Instanced Collection",
     "description": "Edit a Collection Instance's source Collection (even if it is not in the Scene).",
     "author": "FLEB",
-    "version": (0, 2, 3),
+    "version": (0, 2, 4),
     "blender": (3, 1, 0),
     "location": "Object > Edit Instanced Collection",
     "doc_url": "https://github.com/SuperFLEB/BlenderEditCollectionAddon",
@@ -34,9 +34,15 @@ class EditCollection(bpy.types.Operator):
             self.report({"WARNING"}, "Active item is not a collection instance")
             return {"CANCELLED"}
 
+        # settings["original_scene"] = context.scene.name[:64] #.substring(0, 64)
         settings["original_scene"].append(context.scene.name[:64]) #.substring(0, 64)
+        settings["view_layer"].append(context.window.view_layer.name) #.substring(0, 64)
         scene_name = f"temp:{str(coll.name)[:50]}"
         # print("Scene_name %s" % scene_name)
+        # print("original_scene %s" % settings["original_scene"])
+        # print("tmp_scene %s" % settings["tmp_scene"])
+        # print("view_layer %s" % settings["view_layer"])
+        # print("view_layer %s" % settings["view_layer"][0])
         # print("Scene_name %s" % str(tmp_name)[:10])
         # print("Scene_name %s" % scene_name[:10])
         # print("Scene_name %s" % scene_name[:20])
@@ -100,6 +106,7 @@ class EditCollection(bpy.types.Operator):
 settings = {
     "original_scene": [],
     "tmp_scene": [],
+    "view_layer": [],
     # "linked_objects": [],
     # "linked_nodes": []
     }
@@ -113,12 +120,15 @@ class EIC_OP_ReturntoScene(bpy.types.Operator):
     scene : bpy.props.StringProperty()
 
     def execute(self, context):
+        print("Scene %s" % self.scene)
         if (self.scene == "previous"):
             settings["tmp_scene"].remove(context.scene.name)
             if (settings["tmp_scene"] == 0):
                 settings["original_scene"] =[]
+                settings["view_layer"] =[]
             else:
                 settings["original_scene"].pop(len(settings["original_scene"])-1)
+                settings["view_layer"].pop(len(settings["view_layer"])-1)
 
             bpy.ops.scene.delete()
             bpy.ops.view3d.view_selected(use_all_regions=False)
@@ -128,9 +138,13 @@ class EIC_OP_ReturntoScene(bpy.types.Operator):
                 bpy.context.window.scene = bpy.data.scenes[scn]
                 bpy.ops.scene.delete()
             bpy.ops.view3d.view_selected(use_all_regions=False)
+            context.window.view_layer = context.scene.view_layers[settings['view_layer'][0]]
             settings["original_scene"] = []
             settings["tmp_scene"] = []
+            settings["view_layer"] = []
             # logger.info("Back to the original!")
+        #frame selected    
+        bpy.ops.view3d.view_selected(use_all_regions=False)
         return {'FINISHED'}
 
 class EIC_PT_PanelLinkedEdit(bpy.types.Panel):
@@ -143,7 +157,17 @@ class EIC_PT_PanelLinkedEdit(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context: bpy.context):
+        # print(context.active_object)
+        # return settings["original_scene"] != ""
         return (context.active_object is not None) or (settings["original_scene"] != [])
+
+    # def draw_common(self, scene, layout, props):
+    #     if props is not None:
+    #         props.use_autosave = scene.use_autosave
+    #         props.use_instance = scene.use_instance
+
+    #         layout.prop(scene, "use_autosave")
+    #         layout.prop(scene, "use_instance")
 
     def draw(self, context: bpy.context):
         scene = context.scene
@@ -151,18 +175,71 @@ class EIC_PT_PanelLinkedEdit(bpy.types.Panel):
         layout.use_property_split = False
         layout.use_property_decorate = False
 
+        # layout.operator("object.eic_return_to_scene")
+
         target = None
 
         icon = 'OUTLINER_COLLECTION'
         try:
+            # icon = "OUTLINER_DATA_" + context.active_object.type.replace("LIGHT_PROBE", "LIGHTPROBE")
             target = context.active_object
+        
             if settings["original_scene"] == "" or settings["original_scene"] != "" and (target.instance_collection is not None):
+            # if settings["original_scene"] == "" and (target is not None):
+                    # (target and
+                    # target.library is not None) or
+                    # context.active_object.library is not None or
+                    # (context.active_object.override_library is not None and
+                    # context.active_object.override_library.reference is not None)):
+
                 if (target.instance_collection is not None):
                     props = layout.operator("object.edit_collection", icon="LINK_BLEND",
                                             text="Edit Collection") # %s" % target.name)
+            #     elif (context.active_object.library):
+            #         props = layout.operator("object.edit_linked", icon="LINK_BLEND",
+            #                                 text="Edit Library: %s" % context.active_object.name)
+            #     else:
+            #         props = layout.operator("object.edit_linked", icon="LINK_BLEND",
+            #                                 text="Edit Override Library: %s" % context.active_object.override_library.reference.name)
 
+            #     self.draw_common(scene, layout, props)
+
+            #     if (target is not None):
+            #         layout.label(text="Path: %s" %
+            #                     target.library.filepath)
+            #     elif (context.active_object.library):
+            #         layout.label(text="Path: %s" %
+            #                     context.active_object.library.filepath)
+            #     else:
+            #         layout.label(text="Path: %s" %
+            #                     context.active_object.override_library.reference.library.filepath)
             else:
                 layout.label(text="%s is not linked" % context.active_object.name,icon=icon)
+            
+            
+            #         layout.separator()
+
+            #         # XXX - This is for nested linked assets... but it only works
+            #         # when launching a new Blender instance. Nested links don't
+            #         # currently work when using a single instance of Blender.
+            #         if context.active_object.instance_collection is not None:
+            #             props = layout.operator("object.edit_linked",
+            #                     text="Edit Library: %s" % context.active_object.instance_collection.name,
+            #                     icon="LINK_BLEND")
+            #         else:
+            #             props = None
+
+            #         self.draw_common(scene, layout, props)
+
+            #         if context.active_object.instance_collection is not None:
+            #             layout.label(text="Path: %s" %
+            #                     context.active_object.instance_collection.library.filepath)
+
+            #     else:
+            #         props = layout.operator("wm.return_to_original", icon="LOOP_BACK")
+            #         props.use_autosave = scene.use_autosave
+
+            #         layout.prop(scene, "use_autosave")
         except:
             pass
         if settings["original_scene"] != []:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ bl_info = {
     "name": "Edit Instanced Collection",
     "description": "Edit a Collection Instance's source Collection (even if it is not in the Scene).",
     "author": "FLEB",
-    "version": (0, 2, 4),
+    "version": (0, 2, 6),
     "blender": (3, 1, 0),
     "location": "Object > Edit Instanced Collection",
     "doc_url": "https://github.com/SuperFLEB/BlenderEditCollectionAddon",
@@ -56,24 +56,27 @@ class EditCollection(bpy.types.Operator):
         settings["tmp_scene"].append(scene_name)
 
         if prefs.world_texture != "none":
-            world = bpy.data.worlds.new(bpy.context.scene.name)
-            new_scene.world = world
-            world.use_nodes = True
-            tree = world.node_tree
+                world = bpy.data.worlds.new(bpy.context.scene.name)
+                new_scene.world = world
+                world.use_nodes = True
+                tree = world.node_tree
 
-            if prefs.world_texture in ["checker", "checker_view"]:
-                checker_texture = tree.nodes.new("ShaderNodeTexChecker")
-                checker_texture.inputs["Scale"].default_value = 20
-                checker_texture.location = Vector((-250, 0))
-                if prefs.world_texture == "checker_view":
-                    coord = tree.nodes.new("ShaderNodeTexCoord")
-                    coord.location = Vector((-500, 0))
-                    for op in coord.outputs:
-                        op.hide = True
-                    tree.links.new(coord.outputs["Window"], checker_texture.inputs["Vector"])
-                tree.links.new(checker_texture.outputs["Color"], tree.nodes["Background"].inputs["Color"])
-            elif prefs.world_texture == "gray":
-                tree.nodes["Background"].inputs["Color"].default_value = (.3, .3, .3, 1)
+                if prefs.world_texture == "active":
+                    print(settings["original_scene"][0])
+                    bpy.context.scene.world = bpy.data.scenes[settings["original_scene"][0]].world
+                if prefs.world_texture in ["checker", "checker_view"]:
+                    checker_texture = tree.nodes.new("ShaderNodeTexChecker")
+                    checker_texture.inputs["Scale"].default_value = 20
+                    checker_texture.location = Vector((-250, 0))
+                    if prefs.world_texture == "checker_view":
+                        coord = tree.nodes.new("ShaderNodeTexCoord")
+                        coord.location = Vector((-500, 0))
+                        for op in coord.outputs:
+                            op.hide = True
+                        tree.links.new(coord.outputs["Window"], checker_texture.inputs["Vector"])
+                    tree.links.new(checker_texture.outputs["Color"], tree.nodes["Background"].inputs["Color"])
+                elif prefs.world_texture == "gray":
+                    tree.nodes["Background"].inputs["Color"].default_value = (.3, .3, .3, 1)
 
         # Select the collection
         bpy.context.view_layer.active_layer_collection = bpy.context.view_layer.layer_collection.children[coll.name]
@@ -120,7 +123,7 @@ class EIC_OP_ReturntoScene(bpy.types.Operator):
     scene : bpy.props.StringProperty()
 
     def execute(self, context):
-        print("Scene %s" % self.scene)
+        # print("Scene %s" % self.scene)
         if (self.scene == "previous"):
             settings["tmp_scene"].remove(context.scene.name)
             if (settings["tmp_scene"] == 0):
@@ -138,6 +141,10 @@ class EIC_OP_ReturntoScene(bpy.types.Operator):
                 bpy.context.window.scene = bpy.data.scenes[scn]
                 bpy.ops.scene.delete()
             bpy.ops.view3d.view_selected(use_all_regions=False)
+            # print(f"View_layer: {settings['view_layer'][0]}")
+            # # print(f"View_layer: {settings['view_layer'][1]}")
+            # print(f"Org_scen: {settings['original_scene'][0]}")
+            bpy.context.window.scene = bpy.data.scenes[settings["original_scene"][0]]
             context.window.view_layer = context.scene.view_layers[settings['view_layer'][0]]
             settings["original_scene"] = []
             settings["tmp_scene"] = []
@@ -264,7 +271,8 @@ class EditInstancedCollectionPreferences(bpy.types.AddonPreferences):
             ("checker", "Checker (generated map)", "Checker-like texture using a Generated map"),
             ("checker_view", "Checker (view aligned)", "Checkerboard texture aligned to the view"),
             ("gray", "Gray", "Solid Gray Background"),
-            ("none", "None", "No World/background (black)")
+            ("none", "None", "No World/background (black)"),
+            ("active", "Active", "Use current active World")
         ]
     )
 


### PR DESCRIPTION
As noted before this adds an easier workflow. It adds a panel in the Item Panel (N). Its basically sort of a copy of how "Edit Linked Libraries" works. So opening the panel we "Edit Collection", works same as before. When we enter the collection, we see a button "Return to Scene", this does as described but also automatically deletes the tmp scene. 

If there nested collection, upon selecting those, we see again "Edit Collection". When entered, we now see buttons depending on what is selected. Most times it will show "Previous Collection", which will guide to back to the prior collection we came from. It will also show "Return to Scene". When this is clicked all tmp scenes will be deleted.

This edit also will center view and zoom to item. I saw quite some folks getting zoomed out a lot but also way of track of the view

Note; I still need to clean the file. There is old and pasted coded in there i need to get rid of.